### PR TITLE
Consolidate context constant Psalm suppression

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -20,12 +20,5 @@
                 <file name="src/RedisDsnProvider.php" />
             </errorLevel>
         </UndefinedClass>
-        <!-- Koriym\SemanticLogger\AbstractContext declares TYPE/SCHEMA_URL = '' (untyped), which Psalm
-             infers as the literal '' type; concrete Context subclasses legitimately set string values. -->
-        <InvalidClassConstantType>
-            <errorLevel type="suppress">
-                <directory name="src/Log/Context" />
-            </errorLevel>
-        </InvalidClassConstantType>
     </issueHandlers>
 </psalm>

--- a/src/Log/Context/AbstractRepositoryContext.php
+++ b/src/Log/Context/AbstractRepositoryContext.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\QueryRepository\Log\Context;
+
+use Koriym\SemanticLogger\AbstractContext;
+
+abstract class AbstractRepositoryContext extends AbstractContext
+{
+    /**
+     * Upstream declares this as the literal empty string; concrete contexts provide semantic type names.
+     *
+     * @var string
+     * @psalm-suppress LessSpecificClassConstantType
+     */
+    public const TYPE = '';
+
+    /**
+     * Upstream declares this as the literal empty string; concrete contexts provide schema URLs.
+     *
+     * @var string
+     * @psalm-suppress LessSpecificClassConstantType
+     */
+    public const SCHEMA_URL = '';
+}

--- a/src/Log/Context/AbstractRepositoryContext.php
+++ b/src/Log/Context/AbstractRepositoryContext.php
@@ -6,12 +6,13 @@ namespace BEAR\QueryRepository\Log\Context;
 
 use Koriym\SemanticLogger\AbstractContext;
 
+/** @SuppressWarnings("PHPMD.NumberOfChildren") */
 abstract class AbstractRepositoryContext extends AbstractContext
 {
     /**
      * Upstream declares this as the literal empty string; concrete contexts provide semantic type names.
      *
-     * @var string
+     * @psalm-var string
      * @psalm-suppress LessSpecificClassConstantType
      */
     public const TYPE = '';
@@ -19,7 +20,7 @@ abstract class AbstractRepositoryContext extends AbstractContext
     /**
      * Upstream declares this as the literal empty string; concrete contexts provide schema URLs.
      *
-     * @var string
+     * @psalm-var string
      * @psalm-suppress LessSpecificClassConstantType
      */
     public const SCHEMA_URL = '';

--- a/src/Log/Context/CacheHitContext.php
+++ b/src/Log/Context/CacheHitContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Close/event: a cache lookup hit at the given layer.
  */
-final class CacheHitContext extends AbstractContext
+final class CacheHitContext extends AbstractRepositoryContext
 {
     public const TYPE = 'cache_hit';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/cache_hit.json';

--- a/src/Log/Context/CacheMissContext.php
+++ b/src/Log/Context/CacheMissContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Close/event: a cache lookup miss at the given layer.
  */
-final class CacheMissContext extends AbstractContext
+final class CacheMissContext extends AbstractRepositoryContext
 {
     public const TYPE = 'cache_miss';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/cache_miss.json';

--- a/src/Log/Context/CommandContext.php
+++ b/src/Log/Context/CommandContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Open: a write/command scope (#[Refresh]/#[Purge]); purges nest under it.
  */
-final class CommandContext extends AbstractContext
+final class CommandContext extends AbstractRepositoryContext
 {
     public const TYPE = 'command';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/command.json';

--- a/src/Log/Context/CommandResultContext.php
+++ b/src/Log/Context/CommandResultContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Close of a command scope: the resulting HTTP status code.
  */
-final class CommandResultContext extends AbstractContext
+final class CommandResultContext extends AbstractRepositoryContext
 {
     public const TYPE = 'command_result';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/command_result.json';

--- a/src/Log/Context/DependsOnContext.php
+++ b/src/Log/Context/DependsOnContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: a parent now depends on a child (dependency-graph edge).
  */
-final class DependsOnContext extends AbstractContext
+final class DependsOnContext extends AbstractRepositoryContext
 {
     public const TYPE = 'depends_on';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/depends_on.json';

--- a/src/Log/Context/GetContext.php
+++ b/src/Log/Context/GetContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Open: a resource (or donut) GET scope; embedded child GETs nest under it.
  */
-final class GetContext extends AbstractContext
+final class GetContext extends AbstractRepositoryContext
 {
     public const TYPE = 'get';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/get.json';

--- a/src/Log/Context/InvalidateContext.php
+++ b/src/Log/Context/InvalidateContext.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BEAR\QueryRepository\Log\Context;
 
 use JsonSerializable;
-use Koriym\SemanticLogger\AbstractContext;
 use Override;
 
 /**
@@ -16,7 +15,7 @@ use Override;
  *                       the tag version stale; it does not physically delete)
  *   cdn             -> "purged" | "failed"        (CDN surrogate-key purge)
  */
-final class InvalidateContext extends AbstractContext implements JsonSerializable
+final class InvalidateContext extends AbstractRepositoryContext implements JsonSerializable
 {
     public const TYPE = 'invalidate';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/invalidate.json';

--- a/src/Log/Context/ManualInvalidateContext.php
+++ b/src/Log/Context/ManualInvalidateContext.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Open: an application-initiated (manual) tag invalidation.
  *
@@ -14,7 +12,7 @@ use Koriym\SemanticLogger\AbstractContext;
  * outcome event would be dropped at flush; rooting it here keeps it visible. The
  * outcome is recorded on the close InvalidateContext.
  */
-final class ManualInvalidateContext extends AbstractContext
+final class ManualInvalidateContext extends AbstractRepositoryContext
 {
     public const TYPE = 'manual_invalidate';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/manual_invalidate.json';

--- a/src/Log/Context/ManualPurgeContext.php
+++ b/src/Log/Context/ManualPurgeContext.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Open: an application-initiated (manual) purge of a URI.
  *
  * Emitted only when the purge is top-level (not nested inside a request GET or a
  * write command), so a deliberate cache bust stands out from automatic invalidation.
  */
-final class ManualPurgeContext extends AbstractContext
+final class ManualPurgeContext extends AbstractRepositoryContext
 {
     public const TYPE = 'manual_purge';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/manual_purge.json';

--- a/src/Log/Context/ManualPurgeResultContext.php
+++ b/src/Log/Context/ManualPurgeResultContext.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace BEAR\QueryRepository\Log\Context;
 
 use JsonSerializable;
-use Koriym\SemanticLogger\AbstractContext;
 use Override;
 
 /**
  * Close of a manual_purge scope: whether the local pools were invalidated.
  */
-final class ManualPurgeResultContext extends AbstractContext implements JsonSerializable
+final class ManualPurgeResultContext extends AbstractRepositoryContext implements JsonSerializable
 {
     public const TYPE = 'manual_purge_result';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/manual_purge_result.json';

--- a/src/Log/Context/ManualStoreContext.php
+++ b/src/Log/Context/ManualStoreContext.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Open: an application-initiated (manual) store of a resource.
  *
@@ -13,7 +11,7 @@ use Koriym\SemanticLogger\AbstractContext;
  * write command). A direct put has no enclosing scope, so its save events would
  * be dropped at flush; wrapping it here keeps the write visible in the log.
  */
-final class ManualStoreContext extends AbstractContext
+final class ManualStoreContext extends AbstractRepositoryContext
 {
     public const TYPE = 'manual_store';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/manual_store.json';

--- a/src/Log/Context/ManualStoreResultContext.php
+++ b/src/Log/Context/ManualStoreResultContext.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace BEAR\QueryRepository\Log\Context;
 
 use JsonSerializable;
-use Koriym\SemanticLogger\AbstractContext;
 use Override;
 
 /**
  * Close of a manual_store scope: whether the resource was stored.
  */
-final class ManualStoreResultContext extends AbstractContext implements JsonSerializable
+final class ManualStoreResultContext extends AbstractRepositoryContext implements JsonSerializable
 {
     public const TYPE = 'manual_store_result';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/manual_store_result.json';

--- a/src/Log/Context/PurgeContext.php
+++ b/src/Log/Context/PurgeContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: an explicit purge of a URI was requested.
  */
-final class PurgeContext extends AbstractContext
+final class PurgeContext extends AbstractRepositoryContext
 {
     public const TYPE = 'purge';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/purge.json';

--- a/src/Log/Context/PutDonutContext.php
+++ b/src/Log/Context/PutDonutContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: a donut was put with its TTLs.
  */
-final class PutDonutContext extends AbstractContext
+final class PutDonutContext extends AbstractRepositoryContext
 {
     public const TYPE = 'put_donut';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/put_donut.json';

--- a/src/Log/Context/RefreshDonutContext.php
+++ b/src/Log/Context/RefreshDonutContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: a donut was rebuilt (cache miss path).
  */
-final class RefreshDonutContext extends AbstractContext
+final class RefreshDonutContext extends AbstractRepositoryContext
 {
     public const TYPE = 'refresh_donut';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/refresh_donut.json';

--- a/src/Log/Context/SaveDonutContext.php
+++ b/src/Log/Context/SaveDonutContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: a donut structure (template) was stored.
  */
-final class SaveDonutContext extends AbstractContext
+final class SaveDonutContext extends AbstractRepositoryContext
 {
     public const TYPE = 'save_donut';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/save_donut.json';

--- a/src/Log/Context/SaveDonutViewContext.php
+++ b/src/Log/Context/SaveDonutViewContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: a rendered donut view was stored.
  */
-final class SaveDonutViewContext extends AbstractContext
+final class SaveDonutViewContext extends AbstractRepositoryContext
 {
     public const TYPE = 'save_donut_view';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/save_donut_view.json';

--- a/src/Log/Context/SaveEtagContext.php
+++ b/src/Log/Context/SaveEtagContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: an ETag entry was stored with its surrogate keys.
  */
-final class SaveEtagContext extends AbstractContext
+final class SaveEtagContext extends AbstractRepositoryContext
 {
     public const TYPE = 'save_etag';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/save_etag.json';

--- a/src/Log/Context/SaveValueContext.php
+++ b/src/Log/Context/SaveValueContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: a resource value (body) was stored.
  */
-final class SaveValueContext extends AbstractContext
+final class SaveValueContext extends AbstractRepositoryContext
 {
     public const TYPE = 'save_value';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/save_value.json';

--- a/src/Log/Context/SaveViewContext.php
+++ b/src/Log/Context/SaveViewContext.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository\Log\Context;
 
-use Koriym\SemanticLogger\AbstractContext;
-
 /**
  * Event: a rendered resource view was stored.
  */
-final class SaveViewContext extends AbstractContext
+final class SaveViewContext extends AbstractRepositoryContext
 {
     public const TYPE = 'save_view';
     public const SCHEMA_URL = 'https://bearsunday.github.io/BEAR.QueryRepository/schemas/context/save_view.json';


### PR DESCRIPTION
## Summary

- Remove the broad `InvalidClassConstantType` directory suppression from `psalm.xml`.
- Add `AbstractRepositoryContext` to centralize the Psalm workaround for `Koriym\SemanticLogger\AbstractContext` literal-empty-string constants.
- Update semantic context classes to extend the local intermediate base instead of suppressing every concrete context file.

## Why

`Koriym\SemanticLogger\AbstractContext` declares `TYPE` and `SCHEMA_URL` as empty-string constants. Psalm infers those as the literal `''`, so each concrete context class triggered `InvalidClassConstantType` when it supplied its actual semantic type and schema URL.

The previous config-level suppression was broad. This keeps the workaround local to the semantic context hierarchy and removes the issue handler from `psalm.xml`.

## Validation

- `/opt/homebrew/opt/php@8.4/bin/php ./vendor/bin/psalm --show-info=true --no-progress --no-cache --threads=1 --scan-threads=1`
- `zsh -ic 'sphp85; php -d memory_limit=512M ./vendor/bin/phpstan analyse -c phpstan.neon --debug'`
- `zsh -ic 'sphp85; ./vendor/bin/phpunit tests/SemanticLogSchemaTest.php'`
- `xmllint --noout psalm.xml`
- `git diff --check`
